### PR TITLE
[codex] Add actions security checks

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  actions-security:
+    name: Check workflows
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.56.6
+
+      - name: Check action pinning
+        run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Audit workflows
+        run: zizmor --format github .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,6 +6,9 @@ on:
       - 'python/**'
       - '.github/workflows/python-ci.yml'
 
+
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -14,10 +17,12 @@ jobs:
         working-directory: python
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
 
     - name: Install uv
-      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+      uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       with:
         version: "latest"
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -6,6 +6,9 @@ on:
       - 'rust/**'
       - '.github/workflows/rust-ci.yml'
 
+
+permissions:
+  contents: read
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -14,22 +17,24 @@ jobs:
         working-directory: rust
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
 
     - name: Cache cargo registry
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache cargo index
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache target directory
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: rust/target
         key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+registries:
+  - type: standard
+    ref: v4.502.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+  - name: suzuki-shunsuke/pinact@v4.0.0
+  - name: zizmorcore/zizmor@v1.25.2


### PR DESCRIPTION
## Summary
- Pin GitHub Actions references to commit SHAs with pinact annotations
- Add aqua-managed pinact and zizmor tools
- Add a GitHub Actions Security workflow that installs tools via aqua and runs pinact/zizmor
- Set read-only workflow permissions and disable checkout credential persistence where applicable

## Validation
- actionlint .github/workflows/*.{yml,yaml}
- git diff --check -- .github/workflows aqua.yaml