### PR TITLE
Remove redundant setup-uv version input

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -23,8 +23,6 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-      with:
-        version: "latest"
 
     - name: Set up Python
       run: uv python install


### PR DESCRIPTION
## Summary
- remove the explicit `version: "latest"` input from `astral-sh/setup-uv`
- rely on setup-uv's existing default behavior, which installs latest when no repository-level uv required-version is configured

## Validation
- `git diff --check`
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor --format plain .`
- `uv sync --directory python --dev`
- `uv run --directory python python -c "from magika import Magika; Magika()"`
- `uv run --directory python ruff check .`
- `uv run --directory python ruff format --check .`