### PR TITLE
Pin dependencies without changing the Python requirement

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,12 +5,12 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "magika>=1.0.1",
+    "magika==1.0.3",
 ]
 
 [dependency-groups]
 dev = [
-    "ruff>=0.14.5",
+    "ruff==0.14.5",
 ]
 
 [tool.ruff]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -300,10 +300,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "magika", specifier = ">=1.0.1" }]
+requires-dist = [{ name = "magika", specifier = "==1.0.3" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.14.5" }]
+dev = [{ name = "ruff", specifier = "==0.14.5" }]
 
 [[package]]
 name = "ruff"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-magika = "1.0"
-ort = { version = "2.0.0-rc.10", features = ["download-binaries"] }
-walkdir = "2"
-anyhow = "1"
+magika = "=1.1.0"
+ort = { version = "=2.0.0-rc.12", features = ["download-binaries"] }
+walkdir = "=2.5.0"
+anyhow = "=1.0.103"


### PR DESCRIPTION
## Summary

- pin the Python Magika and Ruff dependencies to the versions already recorded in `uv.lock`
- pin the Rust dependencies to the versions already recorded in `Cargo.lock`
- keep `requires-python = ">=3.11"` instead of the invalid `==0.1.0` change in #76
- refresh only the dependency specifiers in `python/uv.lock`

## Why

Renovate PR #76 combines the intended dependency pins with an invalid Python requirement. Python 3.14 cannot satisfy `requires-python ==0.1.0`, so both `uv lock` and Python CI fail. This PR carries the safe pin changes on a separate branch while preserving the valid runtime requirement.

The pinned versions were already resolved by the default branch lockfiles, so this does not change the installed dependency versions.

## Validation

- `uv sync --dev`
- `uv run python -c "from magika import Magika; Magika()"`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo fmt --check`
- `cargo test`
- `cargo build --release`
